### PR TITLE
lavc/h264_qsv: Add an option to force key-frames as IDR.

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -687,8 +687,11 @@ int ff_qsv_encode(AVCodecContext *avctx, QSVEncContext *q,
             av_log(avctx, AV_LOG_ERROR, "Error submitting the frame for encoding.\n");
             return ret;
         }
-        if (frame->pict_type == AV_PICTURE_TYPE_I)
+        if (frame->pict_type == AV_PICTURE_TYPE_I) {
             ctrl.FrameType = MFX_FRAMETYPE_I | MFX_FRAMETYPE_REF;
+            if (q->force_idr)
+                ctrl.FrameType |= MFX_FRAMETYPE_IDR;
+        }
     }
 
     ret = av_new_packet(&new_pkt, q->packet_size);

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -131,6 +131,9 @@ typedef struct QSVEncContext {
     //for HEVC
     int has_vps;
 
+    //for H.264
+    int force_idr;
+
     char *load_plugins;
 } QSVEncContext;
 

--- a/libavcodec/qsvenc_h264.c
+++ b/libavcodec/qsvenc_h264.c
@@ -153,6 +153,8 @@ static const AVOption options[] = {
     { "glo_motion_bias_adj","Enables global motion bias", OFFSET(qsv.enable_global_motion_bias), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE },
     { "mv_cost_sf",         "MV cost scaling ratio", OFFSET(qsv.mv_cost_sf), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 3, VE },
 
+    { "force_idr",          "If forcing key-frames, force them as IDR frames.", OFFSET(qsv.force_idr), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE },
+
     { NULL },
 };
 


### PR DESCRIPTION
Signed-off-by: ChaoX A Liu <chaox.a.liu@intel.com>