### PR TITLE
lavf/qsv: release the frame in filter_frame().

### DIFF
--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -340,9 +340,10 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *picref)
     VPPContext       *vpp = inlink->dst->priv;
     AVFilterLink     *outlink = ctx->outputs[0];
 
-    if (vpp->qsv)
+    if (vpp->qsv) {
         ret = ff_qsvvpp_filter_frame(vpp->qsv, inlink, picref);
-    else {
+        av_frame_free(&picref);
+    } else {
         if (picref->pts != AV_NOPTS_VALUE)
             picref->pts = av_rescale_q(picref->pts, inlink->time_base, outlink->time_base);
         ret = ff_filter_frame(outlink, picref);


### PR DESCRIPTION
We must release the input frame in filter_frame().
but for filters like overlay, which is based on framesync.
the input frame was managed by framesync.c.
To handle this problem, we clone the frame in qsvvpp.c
when filtering a frame. So as we are adding an frame_clone()
in qsvvpp.c, we need to add back the frame release
for filters that is not based on framesync.

Signed-off-by: Ruiling Song <ruiling.song@intel.com>