### PR TITLE
localize input mfxFrameSurface1* for scale_qsv

### DIFF
--- a/libavfilter/vf_scale_qsv.c
+++ b/libavfilter/vf_scale_qsv.c
@@ -543,6 +543,7 @@ static int qsvscale_filter_frame(AVFilterLink *link, AVFrame *in)
         goto fail;
     }
 
+    mfxFrameSurface1 in_surf = *(mfxFrameSurface1*)in->data[3];
     do {
         err = MFXVideoVPP_RunFrameVPPAsync(s->session,
                                            (mfxFrameSurface1*)in->data[3],

--- a/libavfilter/vf_scale_qsv.c
+++ b/libavfilter/vf_scale_qsv.c
@@ -546,7 +546,7 @@ static int qsvscale_filter_frame(AVFilterLink *link, AVFrame *in)
     mfxFrameSurface1 in_surf = *(mfxFrameSurface1*)in->data[3];
     do {
         err = MFXVideoVPP_RunFrameVPPAsync(s->session,
-                                           (mfxFrameSurface1*)in->data[3],
+                                           &in_surf,
                                            (mfxFrameSurface1*)out->data[3],
                                            NULL, &sync);
         if (err == MFX_WRN_DEVICE_BUSY)


### PR DESCRIPTION
If scale_qsv + enc and ONLY enc called by different thread,  ONLY enc may got a Locked mfxFrameSurface1(https://github.com/Intel-FFmpeg-Plugin/Intel_FFmpeg_plugins/blob/bd1a484e986b95052f9a15d444ee747746d706aa/libavcodec/qsvenc.c#L1120) which is Locked by scale_qsv + enc's scale_qsv, and this surf would never be Unlocked, and this surf in qsv_pool(https://github.com/Intel-FFmpeg-Plugin/Intel_FFmpeg_plugins/blob/bd1a484e986b95052f9a15d444ee747746d706aa/libavutil/hwcontext_qsv.c#L379) is "leak".

If scale_qsv also localize input surf like enc, ONLY enc would never got a Locked  mfxFrameSurface1,  it's OK.