### PR TITLE
[3.3.1] ffmpeg-qsv h.264 ignores -bufsize:v option

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -451,6 +451,7 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
 #if QSV_HAVE_VCM
     case MFX_RATECONTROL_VCM:
 #endif
+        q->param.mfx.BufferSizeInKB   = avctx->rc_buffer_size / 8000;
         q->param.mfx.InitialDelayInKB = avctx->rc_initial_buffer_occupancy / 1000;
         q->param.mfx.TargetKbps       = avctx->bit_rate / 1000;
         q->param.mfx.MaxKbps          = avctx->rc_max_rate / 1000;


### PR DESCRIPTION
Fixes: #39

This is a backport from upstream ffmpeg, see https://github.com/FFmpeg/FFmpeg/commit/6ff29343b01923e9b125fe7404ac8701cdfb1fe5
